### PR TITLE
Slightly cleaner 'wireless block extender too far to be linked' message ...

### DIFF
--- a/java/com/dynious/blex/block/BlockExtender.java
+++ b/java/com/dynious/blex/block/BlockExtender.java
@@ -126,9 +126,7 @@ public class BlockExtender extends BlockContainer
                             if (world.isRemote)
                             {
                                 player.sendChatToPlayer(new ChatMessageComponent()
-                                        .addText(BlockHelper.getTileEntityDisplayName(tile) + " is too far from the linked position"));
-                                player.sendChatToPlayer(new ChatMessageComponent()
-                                        .addText(BlockHelper.getTileEntityDisplayName(tile) + " max range: " + Settings.MAX_RANGE_WIRELESS_BLOCK_EXTENDER));
+                                        .addText("The " + BlockHelper.getTileEntityDisplayName(tile) + " is too far from the linked position (max range: " + Settings.MAX_RANGE_WIRELESS_BLOCK_EXTENDER + ")"));
                             }
                         }
                         return true;


### PR DESCRIPTION
...(combined 2 lines into 1)
