### PR TITLE
Simple visual indication for a block extender having connections

### DIFF
--- a/java/com/dynious/blex/renderer/RendererBlockExtender.java
+++ b/java/com/dynious/blex/renderer/RendererBlockExtender.java
@@ -32,7 +32,9 @@ public class RendererBlockExtender extends TileEntitySpecialRenderer
 
             GL11.glPushMatrix();
 
-            float yOffset = (float) Math.sin((float) (System.currentTimeMillis() / 2 % (Math.PI * 1000F)) / 100F) / 10F;
+            float yOffset = 0.0F;
+            if (tile.hasConnection())
+                yOffset = (float) Math.sin((float) (System.currentTimeMillis() / 2 % (Math.PI * 1000F)) / 100F) / 10F;
 
             GL11.glTranslated(0, 1F + yOffset, 0);
             GL11.glRotatef((float) (System.currentTimeMillis() % 36000) / 10F, 0F, 1F, 0F);

--- a/java/com/dynious/blex/tileentity/TileBlockExtender.java
+++ b/java/com/dynious/blex/tileentity/TileBlockExtender.java
@@ -253,7 +253,7 @@ public class TileBlockExtender extends TileEntity implements ISidedInventory, IF
         setEnergyHandler(null);
     }
 
-    protected boolean hasConnection()
+    public boolean hasConnection()
     {
         if (inventory != null || fluidHandler != null)
         {


### PR DESCRIPTION
the ender pearl only moves back and forth when the block extender has a connection

Implements https://github.com/Dynious/BlockExtenders/issues/13
