### PR TITLE
Fixed a few bugs with insert directions/spreading

### DIFF
--- a/java/com/dynious/blex/tileentity/TileAdvancedBlockExtender.java
+++ b/java/com/dynious/blex/tileentity/TileAdvancedBlockExtender.java
@@ -62,12 +62,12 @@ public class TileAdvancedBlockExtender extends TileBlockExtender implements IAdv
     {
         if (spreadItems)
         {
-            if (lastSide != getInputSide(ForgeDirection.getOrientation(i2)).ordinal() || !ItemStackHelper.areItemStacksEqual(itemStack, lastStack) || shouldUpdateBestSlot)
+            if (shouldUpdateBestSlot || lastSide != i2 || !ItemStackHelper.areItemStacksEqual(itemStack, lastStack))
             {
-                updateBestSlot(getInputSide(ForgeDirection.getOrientation(i2)).ordinal(), itemStack);
+                updateBestSlot(i2, itemStack);
                 shouldUpdateBestSlot = false;
             }
-            if (i != bestSlot || !super.canInsertItem(bestSlot, itemStack, getInputSide(ForgeDirection.getOrientation(i2)).ordinal()))
+            if (i != bestSlot || !super.canInsertItem(bestSlot, itemStack, i2))
             {
                 return false;
             }
@@ -76,15 +76,18 @@ public class TileAdvancedBlockExtender extends TileBlockExtender implements IAdv
         }
         else
         {
-            return super.canInsertItem(i, itemStack, insertDirection[i2]);
+            return super.canInsertItem(i, itemStack, i2);
         }
     }
 
     private void updateBestSlot(int side, ItemStack itemStack)
     {
         int bestSize = Integer.MAX_VALUE;
-        for (int slot = 0; slot < getSizeInventory(); slot++)
+        int[] invAccessibleSlots = getAccessibleSlotsFromSide(side);
+
+        for (int j = 0; j < invAccessibleSlots.length; ++j)
         {
+            int slot = invAccessibleSlots[j];
             ItemStack stack = getStackInSlot(slot);
             if (!super.canInsertItem(slot, itemStack, side))
             {

--- a/java/com/dynious/blex/tileentity/TileAdvancedFilteredBlockExtender.java
+++ b/java/com/dynious/blex/tileentity/TileAdvancedFilteredBlockExtender.java
@@ -70,12 +70,12 @@ public class TileAdvancedFilteredBlockExtender extends TileBlockExtender impleme
     {
         if (spreadItems)
         {
-            if (lastSlotSide != getInputSide(ForgeDirection.getOrientation(i2)).ordinal() || !ItemStackHelper.areItemStacksEqual(itemStack, lastStack) || shouldUpdateBestSlot)
+            if (shouldUpdateBestSlot || lastSlotSide != i2 || !ItemStackHelper.areItemStacksEqual(itemStack, lastStack))
             {
                 updateBestSlot(i2, itemStack);
                 shouldUpdateBestSlot = false;
             }
-            if (i != bestSlot || !super.canInsertItem(bestSlot, itemStack, getInputSide(ForgeDirection.getOrientation(i2)).ordinal()))
+            if (i != bestSlot || !super.canInsertItem(bestSlot, itemStack, i2))
             {
                 return false;
             }
@@ -84,15 +84,19 @@ public class TileAdvancedFilteredBlockExtender extends TileBlockExtender impleme
         }
         else
         {
-            return super.canInsertItem(i, itemStack, getInputSide(ForgeDirection.getOrientation(i2)).ordinal()) && (blacklist ? !filter.passesFilter(itemStack) : filter.passesFilter(itemStack));
+            return super.canInsertItem(i, itemStack, i2) && (blacklist ? !filter.passesFilter(itemStack) : filter.passesFilter(itemStack));
         }
     }
 
     private void updateBestSlot(int side, ItemStack itemStack)
     {
         int bestSize = Integer.MAX_VALUE;
-        for (int slot = 0; slot < getSizeInventory(); slot++)
+        int[] invAccessibleSlots = getAccessibleSlotsFromSide(side);
+
+        for (int j = 0; j < invAccessibleSlots.length; ++j)
         {
+            int slot = invAccessibleSlots[j];
+            
             ItemStack stack = getStackInSlot(slot);
             if (!super.canInsertItem(slot, itemStack, side))
             {


### PR DESCRIPTION
- Advanced/AdvancedFiltered block extenders were sending a modified insert direction every time they called super methods (for example: canInsertItem), meaning by the time the direction actually got used, it'd have been sent through getInputSide() two or three times, making the side that was checked totally arbitrary. Basically, Advanced/AdvancedFiltered block extenders should check the correct sides when trying to insert things now
- Fixed updateBestSlot being able to set the best slot to an inaccessible slot and getting itself stuck
