### PR TITLE
Added support for filtering manual inputs into the Filtering Hopper Gui slots

### DIFF
--- a/java/com/dynious/blex/block/BlockFilteringHopper.java
+++ b/java/com/dynious/blex/block/BlockFilteringHopper.java
@@ -38,9 +38,12 @@ public class BlockFilteringHopper extends BlockHopper
     @Override
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int par6, float par7, float par8, float par9)
     {
-        if (!world.isRemote && player.isSneaking())
+        if (!world.isRemote)
         {
-            FMLNetworkHandler.openGui(player, BlockExtenders.instance, GuiIds.FILTERED, world, x, y, z);
+            if (player.isSneaking())
+                FMLNetworkHandler.openGui(player, BlockExtenders.instance, GuiIds.FILTERED, world, x, y, z);
+            else
+                FMLNetworkHandler.openGui(player, BlockExtenders.instance, GuiIds.FILTERING_HOPPER, world, x, y, z);
             return true;
         }
         return super.onBlockActivated(world, x, y, z, player, par6, par7, par8, par9);

--- a/java/com/dynious/blex/gui/GuiFilteringHopper.java
+++ b/java/com/dynious/blex/gui/GuiFilteringHopper.java
@@ -1,0 +1,47 @@
+package com.dynious.blex.gui;
+
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.util.ResourceLocation;
+import org.lwjgl.opengl.GL11;
+import com.dynious.blex.gui.container.ContainerFilteringHopper;
+import com.dynious.blex.tileentity.TileFilteringHopper;
+
+public class GuiFilteringHopper extends GuiContainer
+{
+    private static final ResourceLocation hopperGuiTextures = new ResourceLocation("textures/gui/container/hopper.png");
+    private IInventory playerInventory;
+    private IInventory hopperInventory;
+
+    public GuiFilteringHopper(InventoryPlayer par1InventoryPlayer, TileFilteringHopper filteringHopper)
+    {
+        super(new ContainerFilteringHopper(par1InventoryPlayer, filteringHopper));
+        this.playerInventory = par1InventoryPlayer;
+        this.hopperInventory = filteringHopper;
+        this.allowUserInput = false;
+        this.ySize = 133;
+    }
+
+    /**
+     * Draw the foreground layer for the GuiContainer (everything in front of the items)
+     */
+    protected void drawGuiContainerForegroundLayer(int par1, int par2)
+    {
+        this.fontRenderer.drawString(this.hopperInventory.isInvNameLocalized() ? this.hopperInventory.getInvName() : I18n.getString(this.hopperInventory.getInvName()), 8, 6, 4210752);
+        this.fontRenderer.drawString(this.playerInventory.isInvNameLocalized() ? this.playerInventory.getInvName() : I18n.getString(this.playerInventory.getInvName()), 8, this.ySize - 96 + 2, 4210752);
+    }
+
+    /**
+     * Draw the background layer for the GuiContainer (everything behind the items)
+     */
+    protected void drawGuiContainerBackgroundLayer(float par1, int par2, int par3)
+    {
+        GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+        this.mc.getTextureManager().bindTexture(hopperGuiTextures);
+        int k = (this.width - this.xSize) / 2;
+        int l = (this.height - this.ySize) / 2;
+        this.drawTexturedModalRect(k, l, 0, 0, this.xSize, this.ySize);
+    }
+}

--- a/java/com/dynious/blex/gui/container/ContainerFilteringHopper.java
+++ b/java/com/dynious/blex/gui/container/ContainerFilteringHopper.java
@@ -1,0 +1,174 @@
+package com.dynious.blex.gui.container;
+
+import com.dynious.blex.api.IFilterTile;
+import com.dynious.blex.lib.GuiNetworkIds;
+import com.dynious.blex.network.PacketTypeHandler;
+import com.dynious.blex.network.packet.PacketUserFilter;
+import cpw.mods.fml.common.network.PacketDispatcher;
+import cpw.mods.fml.common.network.Player;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.inventory.ContainerHopper;
+import net.minecraft.inventory.ICrafting;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+
+public class ContainerFilteringHopper extends ContainerHopper implements IContainerFiltered
+{
+    protected final IInventory inventory;
+    protected IFilterTile tile;
+
+    private String lastUserFilter = "";
+    private boolean lastBlacklist = true;
+    private boolean lastFilterOptions[];
+    private boolean initialUpdate = true;
+
+    @SuppressWarnings("unchecked")
+    public ContainerFilteringHopper(InventoryPlayer par1InventoryPlayer, IFilterTile filterTile)
+    {
+        super(par1InventoryPlayer, (IInventory) filterTile);
+        this.tile = filterTile;
+        this.inventory = (IInventory) filterTile;
+
+        for (int i = 0; i < inventory.getSizeInventory(); ++i)
+        {
+            Slot oldSlot = (Slot) this.inventorySlots.get(i);
+            SlotFiltered newSlot = new SlotFiltered(inventory, oldSlot.getSlotIndex(), oldSlot.xDisplayPosition, oldSlot.yDisplayPosition);
+            newSlot.slotNumber = oldSlot.slotNumber;
+            this.inventorySlots.set(i, newSlot);
+        }
+
+        lastFilterOptions = new boolean[tile.getFilter().getSize()];
+    }
+
+    /**
+     * Called when a player shift-clicks on a slot. You must override this or you will crash when someone does that.
+     */
+    public ItemStack transferStackInSlot(EntityPlayer par1EntityPlayer, int par2)
+    {
+        ItemStack itemstack = null;
+        Slot slot = (Slot) this.inventorySlots.get(par2);
+
+        if (slot != null && slot.getHasStack())
+        {
+            ItemStack itemstack1 = slot.getStack();
+            itemstack = itemstack1.copy();
+
+            if (par2 < this.inventory.getSizeInventory())
+            {
+                if (!this.mergeItemStack(itemstack1, this.inventory.getSizeInventory(), this.inventorySlots.size(), true))
+                {
+                    return null;
+                }
+            }
+            else if (!tile.getFilter().passesFilter(itemstack1) || !this.mergeItemStack(itemstack1, 0, this.inventory.getSizeInventory(), false))
+            {
+                return null;
+            }
+
+            if (itemstack1.stackSize == 0)
+            {
+                slot.putStack((ItemStack) null);
+            }
+            else
+            {
+                slot.onSlotChanged();
+            }
+        }
+
+        return itemstack;
+    }
+
+    // Need to get any filter changes while in the Hopper Gui so that the clientside slots can filter properly
+    @Override
+    public void detectAndSendChanges()
+    {
+        super.detectAndSendChanges();
+
+        if (!tile.getFilter().userFilter.equals(lastUserFilter) || initialUpdate)
+        {
+            for (Object crafter : crafters)
+            {
+                if (crafter instanceof EntityPlayer)
+                {
+                    PacketDispatcher.sendPacketToPlayer(PacketTypeHandler.populatePacket(new PacketUserFilter(tile.getFilter().userFilter)), ((Player) crafter));
+                }
+            }
+            lastUserFilter = tile.getFilter().userFilter;
+        }
+
+        for (int i = 0; i < tile.getFilter().getSize(); i++)
+        {
+            if (tile.getFilter().getValue(i) != lastFilterOptions[i] || initialUpdate)
+            {
+                for (Object crafter : crafters)
+                {
+                    ((ICrafting) crafter).sendProgressBarUpdate(this, GuiNetworkIds.FILTERED_BASE + (tile.getFilter().getValue(i) ? 0 : 1), i);
+                }
+                lastFilterOptions[i] = tile.getFilter().getValue(i);
+            }
+        }
+
+        if (tile.getFilter().blacklists != lastBlacklist || initialUpdate)
+        {
+            for (Object crafter : crafters)
+            {
+                ((ICrafting) crafter).sendProgressBarUpdate(this, GuiNetworkIds.FILTERED_BASE + 2, tile.getFilter().blacklists ? 1 : 0);
+            }
+            lastBlacklist = tile.getFilter().blacklists;
+        }
+
+        if (initialUpdate)
+            initialUpdate = false;
+    }
+
+    @Override
+    public void updateProgressBar(int id, int value)
+    {
+        id -= GuiNetworkIds.FILTERED_BASE;
+
+        if (id > GuiNetworkIds.FILTERED_MAX || id < GuiNetworkIds.FILTERED_BASE)
+            return;
+
+        switch (id)
+        {
+            case 0:
+                setFilterOption(value, true);
+                break;
+            case 1:
+                setFilterOption(value, false);
+                break;
+            case 2:
+                setBlackList(value != 0);
+                break;
+        }
+    }
+
+    @Override
+    public void setUserFilter(String filter)
+    {
+        lastUserFilter = filter;
+        tile.getFilter().userFilter = filter;
+    }
+
+    @Override
+    public void setBlackList(boolean value)
+    {
+        lastBlacklist = value;
+        tile.getFilter().blacklists = value;
+    }
+
+    @Override
+    public void setFilterOption(int filterIndex, boolean value)
+    {
+        lastFilterOptions[filterIndex] = value;
+        tile.getFilter().setValue(filterIndex, value);
+    }
+
+    @Override
+    public void toggleFilterOption(int filterIndex)
+    {
+        this.setFilterOption(filterIndex, !tile.getFilter().getValue(filterIndex));
+    }
+}

--- a/java/com/dynious/blex/gui/container/SlotFiltered.java
+++ b/java/com/dynious/blex/gui/container/SlotFiltered.java
@@ -1,0 +1,19 @@
+package com.dynious.blex.gui.container;
+
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+
+public class SlotFiltered extends Slot
+{
+    public SlotFiltered(IInventory inventory, int id, int x, int y)
+    {
+        super(inventory, id, x, y);
+    }
+
+    @Override
+    public boolean isItemValid(ItemStack itemStack)
+    {
+        return inventory.isItemValidForSlot(this.getSlotIndex(), itemStack);
+    }
+}

--- a/java/com/dynious/blex/lib/GuiIds.java
+++ b/java/com/dynious/blex/lib/GuiIds.java
@@ -11,4 +11,6 @@ public class GuiIds
     public static final int ADVANCED_BUFFER = 21;
 
     public static final int FILTERING_CHEST = 30;
+    
+    public static final int FILTERING_HOPPER = 40;
 }

--- a/java/com/dynious/blex/network/GuiHandler.java
+++ b/java/com/dynious/blex/network/GuiHandler.java
@@ -7,6 +7,7 @@ import com.dynious.blex.gui.container.ContainerAdvanced;
 import com.dynious.blex.gui.container.ContainerAdvancedFiltered;
 import com.dynious.blex.gui.container.ContainerFiltered;
 import com.dynious.blex.gui.container.ContainerFilteringChest;
+import com.dynious.blex.gui.container.ContainerFilteringHopper;
 import com.dynious.blex.lib.GuiIds;
 import com.dynious.blex.tileentity.*;
 import cpw.mods.fml.common.Loader;
@@ -46,6 +47,8 @@ public class GuiHandler implements IGuiHandler
                     return GuiFilteringIronChest.makeContainer(GUIChest.GUI.values()[((TileFilteringIronChest)tile).getType().ordinal()], player, (TileFilteringIronChest) tile);
                 }
                 return new ContainerFilteringChest(player, (TileFilteringChest) tile);
+            case GuiIds.FILTERING_HOPPER:
+                return new ContainerFilteringHopper(player.inventory, (IFilterTile) tile);
         }
 
         return null;
@@ -91,6 +94,12 @@ public class GuiHandler implements IGuiHandler
                 if (tile != null && tile instanceof TileFilteringChest)
                 {
                     return new GuiFilteringChest(player, (TileFilteringChest) tile);
+                }
+                break;
+            case GuiIds.FILTERING_HOPPER:
+                if (tile != null && tile instanceof TileFilteringHopper)
+                {
+                    return new GuiFilteringHopper(player.inventory, (TileFilteringHopper) tile);
                 }
                 break;
         }


### PR DESCRIPTION
Sort of a proof of concept for filtered manual inputs. Still not totally sure if you want this or not, but the Filtering Hopper was the perfect thing to implement it on because of how simple the Filtering Hopper is. This opens the door for filtering manual inputs for Filtering Chests, but that might be a bit more complex.

The only sort of weird thing is that I had to duplicate a lot of code from ContainerFiltered (detectAndSendChanges and all related functions) so that the client would get its filter synced when the hopper Gui was opened. I'm also overwriting the inventory slots of the default Hopper with custom SlotFiltered slots.
