### PR TITLE
Fix Disguising chat message in chat

### DIFF
--- a/src/main/resources/assets/refinedrelocation/lang/en_US.lang
+++ b/src/main/resources/assets/refinedrelocation/lang/en_US.lang
@@ -101,7 +101,7 @@ gui.refinedrelocation.none=None
 #Item Description Localizations
 itemDesc.refinedrelocation.linkedPos=Linked position: (%s, %s, %s) (%s)
 itemDesc.refinedrelocation.unlinked=Unlinked
-itemDesc.refinedrelocation.disguisedAs=Disguised (%s, %s, %s)
+itemDesc.refinedrelocation.disguisedAs=Disguised %s as: %s
 itemDesc.refinedrelocation.cannotDisguiseAs=Can not disguise as: %s
 itemDesc.refinedrelocation.linkerSet=Linker set to position: (%s, %s, %s) (%s)
 itemDesc.refinedrelocation.noLongerLinked=Linker is no longer linked


### PR DESCRIPTION
Current chat message returns `Format error: Disguised (%s, %s, %s)`, instead of the correct `Disguised block as: block`. Reverts one line of this commit: 631acbbbec64cebaf8a0a982c076512eb9abae71.

This needs testing, and I am unsure of how to test without this being committed and a snapshot being generated.
