### PR TITLE
Fixed chat message for Block Extenders Redstone Transmission

### DIFF
--- a/src/main/java/com/dynious/refinedrelocation/block/BlockExtender.java
+++ b/src/main/java/com/dynious/refinedrelocation/block/BlockExtender.java
@@ -101,7 +101,7 @@ public class BlockExtender extends BlockContainer implements IDismantleable
                     if (world.isRemote)
                     {
                         player.sendChatToPlayer(new ChatMessageComponent()
-                                .addText(StatCollector.translateToLocal(Strings.REDSTONE_TRANSMISSION) + StatCollector.translateToLocal(blockExtender.isRedstoneTransmissionEnabled() ? Strings.ENABLED : Strings.DISABLED)));
+                                .addText(StatCollector.translateToLocal(Strings.REDSTONE_TRANSMISSION) + ' ' + StatCollector.translateToLocal(blockExtender.isRedstoneTransmissionEnabled() ? Strings.ENABLED : Strings.DISABLED).toLowerCase()));
                     }
                     return true;
                 }


### PR DESCRIPTION
Added a space, lower cased enable/disable, new chat messages in en_US.
`Redstone signal transmission disabled` and `Redstone signal transmission enabled`.
