### PR TITLE
Change one way relocator module to toggle direction on redstone pulse.

### DIFF
--- a/src/main/java/com/dynious/refinedrelocation/grid/relocator/RelocatorModuleOneWay.java
+++ b/src/main/java/com/dynious/refinedrelocation/grid/relocator/RelocatorModuleOneWay.java
@@ -37,7 +37,10 @@ public class RelocatorModuleOneWay extends RelocatorModuleBase
     @Override
     public void onRedstonePowerChange(boolean isPowered)
     {
-        inputAllowed = !inputAllowed;
+        if (isPowered)
+        {
+            inputAllowed = !inputAllowed;
+        }
     }
 
     @Override


### PR DESCRIPTION
This commit changes the one way module to toggle it's direction on redstone pulse. This fixes
`One way module should change direction on redstone pulse.` from #105.
