### PR TITLE
Changes to redstone block module functionality.

### DIFF
--- a/src/main/java/com/dynious/refinedrelocation/grid/relocator/RelocatorModuleRedstoneBlock.java
+++ b/src/main/java/com/dynious/refinedrelocation/grid/relocator/RelocatorModuleRedstoneBlock.java
@@ -5,8 +5,12 @@ import com.dynious.refinedrelocation.api.relocator.RelocatorModuleBase;
 import com.dynious.refinedrelocation.tileentity.IRelocator;
 import com.dynious.refinedrelocation.item.ModItems;
 import com.dynious.refinedrelocation.lib.Resources;
+import com.dynious.refinedrelocation.lib.Strings;
 import net.minecraft.client.renderer.texture.IconRegister;
 import net.minecraft.item.ItemStack;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.ChatMessageComponent;
+import net.minecraft.util.StatCollector;
 import net.minecraft.util.Icon;
 
 import java.util.Arrays;
@@ -16,11 +20,28 @@ public class RelocatorModuleRedstoneBlock extends RelocatorModuleBase
 {
     private static Icon iconOn;
     private static Icon iconOff;
+    private boolean blockOnSignal = true;
 
     @Override
     public boolean passesFilter(IItemRelocator relocator, int side, ItemStack stack, boolean input, boolean simulate)
     {
-        return !relocator.getRedstoneState();
+        return blockOnSignal ? !relocator.getRedstoneState() : relocator.getRedstoneState();
+    }
+
+    @Override
+    public boolean onActivated(IItemRelocator relocator, EntityPlayer player, int side, ItemStack stack)
+    {
+        if (player.worldObj.isRemote)
+        {
+            return true;
+        }
+        else
+        {
+            blockOnSignal = !blockOnSignal;
+            player.sendChatToPlayer(new ChatMessageComponent()
+                .addText(StatCollector.translateToLocal(blockOnSignal ? Strings.REDSTONE_BLOCK_ENABLED : Strings.REDSTONE_BLOCK_DISABLED)));
+            return true;
+        }
     }
 
     @Override
@@ -33,12 +54,13 @@ public class RelocatorModuleRedstoneBlock extends RelocatorModuleBase
     public List<ItemStack> getDrops(IItemRelocator relocator, int side)
     {
         return Arrays.asList(new ItemStack(ModItems.relocatorModule, 1, 7));
+
     }
 
     @Override
     public Icon getIcon(IItemRelocator relocator, int side)
     {
-        return relocator.getRedstoneState() ? iconOn : iconOff;
+        return relocator.getRedstoneState() ? (blockOnSignal ? iconOn : iconOff) : (blockOnSignal ? iconOff : iconOn);
     }
 
     @Override

--- a/src/main/java/com/dynious/refinedrelocation/lib/Strings.java
+++ b/src/main/java/com/dynious/refinedrelocation/lib/Strings.java
@@ -5,6 +5,7 @@ public class Strings
     private static final String GUI_PREFIX = "gui." + Reference.MOD_ID.toLowerCase() + ".";
     private static final String ITEM_DESC_PREFIX = "itemDesc." + Reference.MOD_ID.toLowerCase() + ".";
     private static final String FILTER_NAME_PREFIX = "filterName." + Reference.MOD_ID.toLowerCase() + ".";
+    private static final String RELOCATOR_MODULE_PREFIX = "relocatorModule." + Reference.MOD_ID.toLowerCase() + ".";
 
     public static final String BLACKLIST = GUI_PREFIX + "blacklist";
     public static final String WHITELIST = GUI_PREFIX + "whitelist";
@@ -86,4 +87,7 @@ public class Strings
     public static final String FOOD_FILTER = FILTER_NAME_PREFIX + "filterFood";
     public static final String DYE_FILTER = FILTER_NAME_PREFIX + "filterDyes";
     public static final String NUGGET_FILTER = FILTER_NAME_PREFIX + "filterNuggets";
+
+    public static final String REDSTONE_BLOCK_ENABLED = RELOCATOR_MODULE_PREFIX + "redstoneBlockEnabled";
+    public static final String REDSTONE_BLOCK_DISABLED = RELOCATOR_MODULE_PREFIX + "redstoneBlockDisabled";
 }

--- a/src/main/resources/assets/refinedrelocation/lang/en_US.lang
+++ b/src/main/resources/assets/refinedrelocation/lang/en_US.lang
@@ -141,3 +141,7 @@ filterName.refinedrelocation.filterGems=All Gems
 filterName.refinedrelocation.filterFood=All Food
 filterName.refinedrelocation.filterDyes=All Dyes
 filterName.refinedrelocation.filterNuggets=All Nuggets
+
+#Relocator Module Localizations
+relocatorModule.refinedrelocation.redstoneBlockEnabled=Toggled mode, now blocks items on redstone signal.
+relocatorModule.refinedrelocation.redstoneBlockDisabled=Toggled mode, now allows items through on redstone signal.


### PR DESCRIPTION
These changes allow a redstone block module to either allow or disallow items through on redstone signal. This is toggle able by right clicking the module.

Work needed:
- [ ] Icon doesn't update properly, not sure why. (appears that the `blockOnSignal` variable doesn't change.
- [ ] Module description needs to be changed, I'd like suggestions on that.
