### PR TITLE
Stuffed item improvement

### DIFF
--- a/src/main/java/com/dynious/refinedrelocation/block/BlockRelocator.java
+++ b/src/main/java/com/dynious/refinedrelocation/block/BlockRelocator.java
@@ -113,6 +113,24 @@ public class BlockRelocator extends BlockContainer
     }
 
     @Override
+    public boolean removeBlockByPlayer(World world, EntityPlayer player, int x, int y, int z)
+    {
+        TileEntity tile = world.getBlockTileEntity(x, y, z);
+        if (tile != null && tile instanceof TileRelocator)
+        {
+            MovingObjectPosition hit = RayTracer.retraceBlock(world, player, x, y, z);
+            if (hit != null)
+            {
+                if (!((TileRelocator)tile).leftClick(player, hit, player.getHeldItem()))
+                { // If tile.leftClick returns false, return false, otherwise return super.
+                    return false;
+                }
+            }
+        }
+        return super.removeBlockByPlayer(world, player, x, y, z);
+    }
+
+    @Override
     public MovingObjectPosition collisionRayTrace(World world, int x, int y, int z, Vec3 start, Vec3 end)
     {
         TileEntity tile = world.getBlockTileEntity(x, y, z);

--- a/src/main/java/com/dynious/refinedrelocation/tileentity/TileRelocator.java
+++ b/src/main/java/com/dynious/refinedrelocation/tileentity/TileRelocator.java
@@ -249,6 +249,26 @@ public class TileRelocator extends TileEntity implements IRelocator, ISidedInven
         return false;
     }
 
+    public boolean leftClick(EntityPlayer player, MovingObjectPosition hit, ItemStack item)
+    {
+        if (worldObj.isRemote) return true;
+
+        if (hit.subHit < 6) // Hit side, not middle
+        {
+            int side = hit.subHit;
+            if (!stuffedItems[side].isEmpty())
+            {
+                for (ItemStack stack1 : stuffedItems[side])
+                {
+                    IOHelper.spawnItemInWorld(worldObj, stack1, xCoord, yCoord, zCoord);
+                }
+                markUpdate(worldObj, xCoord, yCoord, zCoord);
+                return false;
+            }
+        }
+        return true;
+    }
+
     public boolean onActivated(EntityPlayer player, MovingObjectPosition hit, ItemStack stack)
     {
         if (hit.subHit < 6)


### PR DESCRIPTION
Still needs work, as:
- [ ] Stuffed items all drop out, not 5 stacks at a time. (Not sure how to do this).
- [ ] If ForgeMultiPart is installed, none of this works. (Needs hooks in `PartRelocator.java`, not sure of method names.)
- [ ] When player hits a relocator, the purple/black untextured particles appear.

Relocators, with this change, will not break if left click on the stuffed connection, and will drop all stuffed items onto ground. If clicked anywhere else on the relocator, the relocator will simply break.

Once everything is done, this will close #130.

@Dynious: Are you sure we shouldn't go with the option of opening a chest like inventory?
