### PR TITLE
Remove the relocation portal from NEI

### DIFF
--- a/src/main/java/com/dynious/refinedrelocation/mods/NEIConfig.java
+++ b/src/main/java/com/dynious/refinedrelocation/mods/NEIConfig.java
@@ -1,0 +1,29 @@
+package com.dynious.refinedrelocation.mods;
+
+import com.dynious.refinedrelocation.api.ModObjects;
+import com.dynious.refinedrelocation.lib.BlockIds;
+import com.dynious.refinedrelocation.lib.Names;
+import com.dynious.refinedrelocation.lib.Reference;
+import codechicken.nei.api.API;
+import codechicken.nei.api.IConfigureNEI;
+
+public class NEIConfig implements IConfigureNEI
+{
+	@Override
+	public void loadConfig()
+	{
+		API.hideItem(BlockIds.RELOCATION_PORTAL);
+	}
+
+	@Override
+	public String getName()
+	{
+		return Reference.NAME;
+	}
+
+	@Override
+	public String getVersion()
+	{
+		return Reference.VERSION;
+	}
+}


### PR DESCRIPTION
As the title says, this adds a new file that removes the untextured relocation portal from NEI.

In testing, this does not crash if NEI is not available.
