### PR TITLE
Remove delay from relocator controller rendering.

### DIFF
--- a/src/main/java/com/dynious/refinedrelocation/renderer/RendererMultiBlock.java
+++ b/src/main/java/com/dynious/refinedrelocation/renderer/RendererMultiBlock.java
@@ -27,49 +27,46 @@ public class RendererMultiBlock extends TileEntitySpecialRenderer
 
                 if (multiBlock != null)
                 {
-                    if (tileMultiBlock.timer % 40 >= 20)
+                    Vector3 leaderPos = multiBlock.getRelativeLeaderPos();
+                    Minecraft.getMinecraft().getTextureManager().bindTexture(TextureMap.locationBlocksTexture);
+
+                    GL11.glPushMatrix();
+                    GL11.glTranslated(xPos + 0.5F, yPos + 0.5F, zPos + 0.5F);
+
+                    for (int x = 0; x < multiBlock.getMultiBlockMap().getSizeX(); x++)
                     {
-                        Vector3 leaderPos = multiBlock.getRelativeLeaderPos();
-                        Minecraft.getMinecraft().getTextureManager().bindTexture(TextureMap.locationBlocksTexture);
-
-                        GL11.glPushMatrix();
-                        GL11.glTranslated(xPos + 0.5F, yPos + 0.5F, zPos + 0.5F);
-
-                        for (int x = 0; x < multiBlock.getMultiBlockMap().getSizeX(); x++)
+                        for (int y = 0; y < multiBlock.getMultiBlockMap().getSizeY(); y++)
                         {
-                            for (int y = 0; y < multiBlock.getMultiBlockMap().getSizeY(); y++)
+                            for (int z = 0; z < multiBlock.getMultiBlockMap().getSizeZ(); z++)
                             {
-                                for (int z = 0; z < multiBlock.getMultiBlockMap().getSizeZ(); z++)
+                                if (!tileMultiBlock.getWorldObj().isAirBlock(tileMultiBlock.xCoord + x - leaderPos.getX(), tileMultiBlock.yCoord + y - leaderPos.getY(), tileMultiBlock.zCoord + z - leaderPos.getZ()))
                                 {
-                                    if (!tileMultiBlock.getWorldObj().isAirBlock(tileMultiBlock.xCoord + x - leaderPos.getX(), tileMultiBlock.yCoord + y - leaderPos.getY(), tileMultiBlock.zCoord + z - leaderPos.getZ()))
-                                    {
-                                        int blockId = tileMultiBlock.getWorldObj().getBlockId(tileMultiBlock.xCoord + x - leaderPos.getX(), tileMultiBlock.yCoord + y - leaderPos.getY(), tileMultiBlock.zCoord + z - leaderPos.getZ());
-                                        Block block = Block.blocksList[blockId];
-                                        if (block != null && block.getRenderType() == 0)
-                                            continue;
-                                    }
-                                    Object blockInfo = multiBlock.getMultiBlockMap().getBlockAndMetaAtPos(x, y, z);
-
-                                    GL11.glPushMatrix();
-
-                                    if (blockInfo instanceof MultiBlockAndMeta)
-                                    {
-                                        MultiBlockAndMeta multiBlockAndMeta = (MultiBlockAndMeta) blockInfo;
-                                        int timePerBlock = 20 / multiBlockAndMeta.getBlockAndMetas().size();
-                                        int blockPlace = (tileMultiBlock.timer % 20) / timePerBlock;
-                                        renderBlock(multiBlockAndMeta.getBlockAndMetas().get(blockPlace), x - leaderPos.getX(), y - leaderPos.getY(), z - leaderPos.getZ());
-                                    }
-                                    else if (blockInfo instanceof BlockAndMeta)
-                                    {
-                                        renderBlock((BlockAndMeta) blockInfo, x - leaderPos.getX(), y - leaderPos.getY(), z - leaderPos.getZ());
-                                    }
-
-                                    GL11.glPopMatrix();
+                                    int blockId = tileMultiBlock.getWorldObj().getBlockId(tileMultiBlock.xCoord + x - leaderPos.getX(), tileMultiBlock.yCoord + y - leaderPos.getY(), tileMultiBlock.zCoord + z - leaderPos.getZ());
+                                    Block block = Block.blocksList[blockId];
+                                    if (block != null && block.getRenderType() == 0)
+                                        continue;
                                 }
+                                Object blockInfo = multiBlock.getMultiBlockMap().getBlockAndMetaAtPos(x, y, z);
+
+                                GL11.glPushMatrix();
+
+                                if (blockInfo instanceof MultiBlockAndMeta)
+                                {
+                                    MultiBlockAndMeta multiBlockAndMeta = (MultiBlockAndMeta) blockInfo;
+                                    int timePerBlock = 20 / multiBlockAndMeta.getBlockAndMetas().size();
+                                    int blockPlace = (tileMultiBlock.timer % 20) / timePerBlock;
+                                    renderBlock(multiBlockAndMeta.getBlockAndMetas().get(blockPlace), x - leaderPos.getX(), y - leaderPos.getY(), z - leaderPos.getZ());
+                                }
+                                else if (blockInfo instanceof BlockAndMeta)
+                                {
+                                    renderBlock((BlockAndMeta) blockInfo, x - leaderPos.getX(), y - leaderPos.getY(), z - leaderPos.getZ());
+                                }
+
+                                GL11.glPopMatrix();
                             }
                         }
-                        GL11.glPopMatrix();
                     }
+                    GL11.glPopMatrix();
                 }
             }
         }
@@ -80,7 +77,7 @@ public class RendererMultiBlock extends TileEntitySpecialRenderer
         if (blockAndMeta.getBlockId() > 0 && Block.blocksList[blockAndMeta.getBlockId()] != null)
         {
             GL11.glTranslatef(relativeX, relativeY, relativeZ);
-            Minecraft.getMinecraft().renderGlobal.globalRenderBlocks.renderBlockAsItem(Block.blocksList[blockAndMeta.getBlockId()], blockAndMeta.getMeta(), 255F);
+            Minecraft.getMinecraft().renderGlobal.globalRenderBlocks.renderBlockAsItem(Block.blocksList[blockAndMeta.getBlockId()], blockAndMeta.getMeta(), 100F);
             //Minecraft.getMinecraft().renderGlobal.globalRenderBlocks.renderBlockByRenderType(Block.blocksList[blockAndMeta.getBlockId()], x - leaderPos.getX(), y - leaderPos.getY(), z - leaderPos.getZ());
         }
     }


### PR DESCRIPTION
No longer has a second when not showing anything, now renders the placeholder constantly.

Preferably, this would be improved further to be semi transparent, but I couldn't find how to do that, and looking at it now, it seems OK without semi transparency.
