### PR TITLE
Change API references from relocator filter to relocator module

### DIFF
--- a/src/main/java/com/dynious/refinedrelocation/APIHandler.java
+++ b/src/main/java/com/dynious/refinedrelocation/APIHandler.java
@@ -45,12 +45,12 @@ public class APIHandler implements IAPIHandler
         return new SortingInventoryHandler(owner);
     }
 
-    public void registerRelocatorFilter(String identifier, Class<? extends IRelocatorModule> clazz) throws IllegalArgumentException
+    public void registerRelocatorModule(String identifier, Class<? extends IRelocatorModule> clazz) throws IllegalArgumentException
     {
         RelocatorModuleRegistry.add(identifier, clazz);
     }
 
-    public void openRelocatorFilterGUI(IItemRelocator relocator, EntityPlayer player, int side)
+    public void openRelocatorModuleGUI(IItemRelocator relocator, EntityPlayer player, int side)
     {
         player.openGui(RefinedRelocation.instance, GuiIds.RELOCATOR_FILTER_BASE + side, relocator.getTileEntity().getWorldObj(), relocator.getTileEntity().xCoord, relocator.getTileEntity().yCoord, relocator.getTileEntity().zCoord);
     }

--- a/src/main/java/com/dynious/refinedrelocation/api/APIUtils.java
+++ b/src/main/java/com/dynious/refinedrelocation/api/APIUtils.java
@@ -71,26 +71,26 @@ public final class APIUtils
     }
 
     /**
-     * Registers a filter for attachment to relocators. To correctly save the filter your
+     * Registers a module for attachment to relocators. To correctly save the filter your
      * filter MUST be registered here.
      *
-     * @param identifier The identifier of this filter
-     * @param clazz The class of this filter
+     * @param identifier The identifier of this module
+     * @param clazz The class of this module
      */
-    public static void registerRelocatorFilter(String identifier, Class<? extends IRelocatorModule> clazz) throws IllegalArgumentException
+    public static void registerRelocatorModule(String identifier, Class<? extends IRelocatorModule> clazz) throws IllegalArgumentException
     {
-        apiHandler.registerRelocatorFilter(identifier, clazz);
+        apiHandler.registerRelocatorModule(identifier, clazz);
     }
 
     /**
-     * Will open a GUI for the filter by calling the getGUI() and getContainer() methods in your filter.
+     * Will open a GUI for the module by calling the getGUI() and getContainer() methods in your module.
      *
-     * @param relocator The identifier of this filter
+     * @param relocator The identifier of this module
      * @param player The Player that the GUI should open for
-     * @param side The side of the filter that should open a GUI
+     * @param side The side of the module that should open a GUI
      */
-    public static void openRelocatorFilterGUI(IItemRelocator relocator, EntityPlayer player, int side)
+    public static void openRelocatorModuleGUI(IItemRelocator relocator, EntityPlayer player, int side)
     {
-        apiHandler.openRelocatorFilterGUI(relocator, player, side);
+        apiHandler.openRelocatorModuleGUI(relocator, player, side);
     }
 }

--- a/src/main/java/com/dynious/refinedrelocation/api/IAPIHandler.java
+++ b/src/main/java/com/dynious/refinedrelocation/api/IAPIHandler.java
@@ -22,7 +22,7 @@ public interface IAPIHandler
 
     public ISortingInventoryHandler createSortingInventoryHandler(TileEntity owner);
 
-    public void registerRelocatorFilter(String identifier, Class<? extends IRelocatorModule> clazz) throws IllegalArgumentException;
+    public void registerRelocatorModule(String identifier, Class<? extends IRelocatorModule> clazz) throws IllegalArgumentException;
 
-    public void openRelocatorFilterGUI(IItemRelocator relocator, EntityPlayer player, int side);
+    public void openRelocatorModuleGUI(IItemRelocator relocator, EntityPlayer player, int side);
 }

--- a/src/main/java/com/dynious/refinedrelocation/grid/relocator/RelocatorModuleExtraction.java
+++ b/src/main/java/com/dynious/refinedrelocation/grid/relocator/RelocatorModuleExtraction.java
@@ -37,7 +37,7 @@ public class RelocatorModuleExtraction extends RelocatorModuleBase
     @Override
     public boolean onActivated(IItemRelocator relocator, EntityPlayer player, int side, ItemStack stack)
     {
-        APIUtils.openRelocatorFilterGUI(relocator, player, side);
+        APIUtils.openRelocatorModuleGUI(relocator, player, side);
         return true;
     }
 

--- a/src/main/java/com/dynious/refinedrelocation/grid/relocator/RelocatorModuleFilter.java
+++ b/src/main/java/com/dynious/refinedrelocation/grid/relocator/RelocatorModuleFilter.java
@@ -40,7 +40,7 @@ public class RelocatorModuleFilter extends RelocatorModuleBase
     @Override
     public boolean onActivated(IItemRelocator relocator, EntityPlayer player, int side, ItemStack stack)
     {
-        APIUtils.openRelocatorFilterGUI(relocator, player, side);
+        APIUtils.openRelocatorModuleGUI(relocator, player, side);
         return true;
     }
 

--- a/src/main/java/com/dynious/refinedrelocation/grid/relocator/RelocatorModuleRegistry.java
+++ b/src/main/java/com/dynious/refinedrelocation/grid/relocator/RelocatorModuleRegistry.java
@@ -66,14 +66,14 @@ public class RelocatorModuleRegistry
 
     public static void registerModules()
     {
-        APIUtils.registerRelocatorFilter("filter", RelocatorModuleFilter.class);
-        APIUtils.registerRelocatorFilter("oneWay", RelocatorModuleOneWay.class);
-        APIUtils.registerRelocatorFilter("extraction", RelocatorModuleExtraction.class);
-        APIUtils.registerRelocatorFilter("blockedExtraction", RelocatorModuleBlockedExtraction.class);
-        APIUtils.registerRelocatorFilter("sneaky", RelocatorModuleSneaky.class);
-        APIUtils.registerRelocatorFilter("stock", RelocatorModuleStock.class);
-        APIUtils.registerRelocatorFilter("redstoneBlock", RelocatorModuleRedstoneBlock.class);
-        APIUtils.registerRelocatorFilter("spread", RelocatorModuleSpread.class);
+        APIUtils.registerRelocatorModule("filter", RelocatorModuleFilter.class);
+        APIUtils.registerRelocatorModule("oneWay", RelocatorModuleOneWay.class);
+        APIUtils.registerRelocatorModule("extraction", RelocatorModuleExtraction.class);
+        APIUtils.registerRelocatorModule("blockedExtraction", RelocatorModuleBlockedExtraction.class);
+        APIUtils.registerRelocatorModule("sneaky", RelocatorModuleSneaky.class);
+        APIUtils.registerRelocatorModule("stock", RelocatorModuleStock.class);
+        APIUtils.registerRelocatorModule("redstoneBlock", RelocatorModuleRedstoneBlock.class);
+        APIUtils.registerRelocatorModule("spread", RelocatorModuleSpread.class);
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/com/dynious/refinedrelocation/grid/relocator/RelocatorModuleSneaky.java
+++ b/src/main/java/com/dynious/refinedrelocation/grid/relocator/RelocatorModuleSneaky.java
@@ -38,7 +38,7 @@ public class RelocatorModuleSneaky extends RelocatorModuleBase
     @Override
     public boolean onActivated(IItemRelocator relocator, EntityPlayer player, int side, ItemStack stack)
     {
-        APIUtils.openRelocatorFilterGUI(relocator, player, side);
+        APIUtils.openRelocatorModuleGUI(relocator, player, side);
         return true;
     }
 

--- a/src/main/java/com/dynious/refinedrelocation/grid/relocator/RelocatorModuleStock.java
+++ b/src/main/java/com/dynious/refinedrelocation/grid/relocator/RelocatorModuleStock.java
@@ -118,7 +118,7 @@ public class RelocatorModuleStock extends RelocatorModuleBase implements IInvent
     @Override
     public boolean onActivated(IItemRelocator relocator, EntityPlayer player, int side, ItemStack stack)
     {
-        APIUtils.openRelocatorFilterGUI(relocator, player, side);
+        APIUtils.openRelocatorModuleGUI(relocator, player, side);
         return true;
     }
 


### PR DESCRIPTION
Changes API references to Filters (the old module name) to Modules, the new name.

This will probably require a new API release.
