### PR TITLE
Add Mod Name to wrench name line

### DIFF
--- a/src/main/java/com/dynious/refinedrelocation/item/ItemToolBox.java
+++ b/src/main/java/com/dynious/refinedrelocation/item/ItemToolBox.java
@@ -137,13 +137,13 @@ public class ItemToolBox extends Item //implements IElectricItem
         ItemStack wrench = getCurrentWrench(stack);
         if (wrench != null)
         {
-            String modName = " (" + BLUE + ITALIC + ModIdentification.nameFromStack(wrench) + RESET + GRAY + ")";
+            String modName = Mods.IS_WAILA_LOADED ? " (" + BLUE + ITALIC + ModIdentification.nameFromStack(wrench) + RESET + GRAY + ")" : "";
             list.add(wrench.getDisplayName() + modName);
         }
         String[] info = StatCollector.translateToLocal(Strings.TOOLBOX_INFO).split("\\\\n");
         for (String line : info)
         {
-            list.add(WHITE + line);
+            list.add("\u00A7f" + line);
         }
     }
 

--- a/src/main/java/com/dynious/refinedrelocation/lib/Mods.java
+++ b/src/main/java/com/dynious/refinedrelocation/lib/Mods.java
@@ -15,6 +15,7 @@ public class Mods
     public static final String UE_ID = "UniversalElectricity";
     public static final String FMP_IS = "McMultipart";
     public static final String METALLURGY_ID = "Metallurgy3Machines";
+    public static final String WAILA_ID = "Waila";
 
 
     public static final boolean IS_IRON_CHEST_LOADED = Loader.isModLoaded(IRON_CHEST_ID);
@@ -27,4 +28,5 @@ public class Mods
     public static final boolean IS_UE_LOADED = Loader.isModLoaded(UE_ID);
     public static final boolean IS_FMP_LOADED = Loader.isModLoaded(FMP_IS);
     public static final boolean IS_METAL_LOADED = Loader.isModLoaded(METALLURGY_ID);
+    public static final boolean IS_WAILA_LOADED = Loader.isModLoaded(WAILA_ID);
 }


### PR DESCRIPTION
This adds the text `(Modname)` after the wrench name in the tooltip. The mod name is italic and is the same color as WAILA's modname in the item footer.

Works if WAILA is not loaded.

Note that the WAILA ModIdentification util is not in WAILA's API.
