### PR TITLE
Adds stack size functionality to extraction module

### DIFF
--- a/src/main/java/com/dynious/refinedrelocation/grid/relocator/RelocatorModuleExtraction.java
+++ b/src/main/java/com/dynious/refinedrelocation/grid/relocator/RelocatorModuleExtraction.java
@@ -68,10 +68,22 @@ public class RelocatorModuleExtraction extends RelocatorModuleBase
                 if (IOHelper.canExtractItemFromInventory(inventory, stack, slot, ForgeDirection.OPPOSITES[side]))
                 {
                     ItemStack stackCopy = stack.copy();
-                    stackCopy.stackSize = Math.min(stackCopy.stackSize, extractStackSize);
+                    int extraStackSize = 0;
+                    if (extractStackSize < stackCopy.stackSize)
+                    {
+                        extraStackSize = stackCopy.stackSize - extractStackSize;
+                        stackCopy.stackSize = extractStackSize;
+                    }
+                    else // Greater than or equal to
+                    {
+                        stackCopy.stackSize = Math.min(stackCopy.stackSize, extractStackSize);
+                    }
+
                     ItemStack returnedStack = relocator.insert(stackCopy, side, false);
+
                     if (returnedStack == null || stack.stackSize != returnedStack.stackSize)
                     {
+                        returnedStack.stackSize += extraStackSize; // Should never be greater than 64
                         inventory.setInventorySlotContents(slot, returnedStack);
                     }
                 }


### PR DESCRIPTION
This needs GUI work, but I thought I'd add this pull request so that whoever does GUI work does not have to do this.

The GUI work required is basically a button that is a max stack size, up to 64. I think it should be 64 - because as far as I know, Minecraft (and mods) try not to have stacks above 64.

@Dynious, @squeek502: I'm terrible at GUIs, so if someone wants to do the GUI that would be great. I'd probably learn a lot from that code. I probably can't do this GUI myself. Maybe in the future, if I explore this much more.
